### PR TITLE
[FIX] championName 추가, 및 allCount,winCount수정

### DIFF
--- a/src/main/java/com/lolduo/duo/service/ChampionDetailComponent2.java
+++ b/src/main/java/com/lolduo/duo/service/ChampionDetailComponent2.java
@@ -42,7 +42,7 @@ public class ChampionDetailComponent2 {
 
         for(Spell spell : spellList){
             String winRate =String.format("%.2f%%", 100 * ((double) spell.getWin() / spell.getAllCount()));
-            String AllCount =String.valueOf(spell.getWin()).replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + " 게임";
+            String AllCount =String.valueOf(spell.getAllCount()).replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + " 게임";
             List<String> spellUrlList = new ArrayList<>();
             for (Long spellId : spell.getSpellMap().get(ChampionId)) {
                 String spellName = spellRepository.findById(spellId).get().getImgUrl();
@@ -75,7 +75,7 @@ public class ChampionDetailComponent2 {
         List<ResponsePerk2> responsePerkList = new ArrayList<>();
         for(Perk perk : perkList){
             String winRate = String.format("%.2f%%", 100 * ((double) perk.getWin() / perk.getAllCount()));
-            String AllCount =String.valueOf(perk.getWin()).replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + " 게임";
+            String AllCount =String.valueOf(perk.getAllCount()).replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + " 게임";
             ResponsePerk2 temp = initResponsePerk(mainPerkId,subPerkId,perk.getPerkMap().get(ChampionId),winRate,AllCount);
             responsePerkList.add(temp);
         }
@@ -123,7 +123,7 @@ public class ChampionDetailComponent2 {
         List<ResponseItem2> responseItemList = new ArrayList<>();
         for(Item item : itemList){
             String winRate =String.format("%.2f%%", 100 * ((double) item.getWin() / item.getAllCount()));
-            String AllCount =String.valueOf(item.getWin()).replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + " 게임";
+            String AllCount =String.valueOf(item.getAllCount()).replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + " 게임";
             List<String> itemUrlList = new ArrayList<>();
             for(Long itemId : item.getItemMap().get(ChampionId).subList(0,3)){
                 String itemName = itemRepository.findById(itemId).get().getImgUrl();


### PR DESCRIPTION
오류 발견 
5번. 0 게임인데 스펠이있음(이즈 카르마)

7번. 승률 계산이 이상하게 되어있는듯 전체 판수에서 그 룬의 판수를 나눈 것이 아닌 그 룬의 전체 판수에서 이긴 판수를 나누어야함 (편집됨) 