### PR TITLE
Fix/summarize item re

### DIFF
--- a/src/main/java/com/lolduo/duo/service/ChampionDetailComponent.java
+++ b/src/main/java/com/lolduo/duo/service/ChampionDetailComponent.java
@@ -119,7 +119,7 @@ public class ChampionDetailComponent {
             return null;
         }
 
-        removeItemsAmountUnderThree(infoEntity);
+        removeItemsAmountUnderNumber(infoEntity, 3);
         List<Item> allItemList = summarize? getSummarizedItemList(infoEntity) : infoEntity.getItemList();
         findTopK(allItemList,2).forEach(item ->
             topItemList.add((Item)item)
@@ -163,7 +163,7 @@ public class ChampionDetailComponent {
         return urlList;
     }
 
-    private void removeItemsAmountUnderThree(ICombiEntity infoEntity) {
+    private void removeItemsAmountUnderNumber(ICombiEntity infoEntity, int number) {
         infoEntity.getItemList().removeIf(item -> {
             for (List<Long> itemIdList : item.getItemMap().values()) {
                 int count = 0;
@@ -174,7 +174,7 @@ public class ChampionDetailComponent {
                         count++;
                 }
 
-                if (count < 3)
+                if (count < number)
                     return true;
             }
             return false;
@@ -182,30 +182,30 @@ public class ChampionDetailComponent {
     }
 
     private List<Item> getSummarizedItemList(ICombiEntity infoEntity) {
-        Map<Map<Long, List<Long>>, List<Long>> itemCombiMatchRecordMap = new HashMap<>();
+        Map<Map<Long, List<Long>>, List<Long>> itemCombiAndWinAllCountsMap = new HashMap<>();
         List<Item> summarizedItemList = new ArrayList<>();
 
         infoEntity.getItemList().forEach(item -> {
             Map<Long, List<Long>> champThreeItemMap = new HashMap<>();
-            item.getItemMap().forEach((championId, wholeItemList) -> {
-                champThreeItemMap.put(championId, wholeItemList.subList(0, 3));
-            });
+            item.getItemMap().forEach((championId, wholeItemList) ->
+                champThreeItemMap.put(championId, wholeItemList.subList(0, 3))
+            );
 
-            if(itemCombiMatchRecordMap.containsKey(champThreeItemMap)) {
-                List<Long> matchRecord = itemCombiMatchRecordMap.get(champThreeItemMap);
-                matchRecord.set(0, matchRecord.get(0) + item.getWin());
-                matchRecord.set(1, matchRecord.get(1) + item.getAllCount());
+            if(itemCombiAndWinAllCountsMap.containsKey(champThreeItemMap)) {
+                List<Long> winAndAllCounts = itemCombiAndWinAllCountsMap.get(champThreeItemMap);
+                winAndAllCounts.set(0, winAndAllCounts.get(0) + item.getWin());
+                winAndAllCounts.set(1, winAndAllCounts.get(1) + item.getAllCount());
             }
             else {
-                List<Long> matchRecord = new ArrayList<>(2);
-                matchRecord.add(item.getWin());
-                matchRecord.add(item.getAllCount());
-                itemCombiMatchRecordMap.put(champThreeItemMap, matchRecord);
+                List<Long> winAndAllCounts = new ArrayList<>(2);
+                winAndAllCounts.add(item.getWin());
+                winAndAllCounts.add(item.getAllCount());
+                itemCombiAndWinAllCountsMap.put(champThreeItemMap, winAndAllCounts);
             }
         });
 
-        itemCombiMatchRecordMap.forEach((threeItemMap, matchRecord) ->
-            summarizedItemList.add(new Item(threeItemMap, matchRecord.get(0), matchRecord.get(1)))
+        itemCombiAndWinAllCountsMap.forEach((threeItemMap, winAndAllCounts) ->
+            summarizedItemList.add(new Item(threeItemMap, winAndAllCounts.get(0), winAndAllCounts.get(1)))
         );
 
         return summarizedItemList;

--- a/src/main/java/com/lolduo/duo/service/ChampionDetailComponent2.java
+++ b/src/main/java/com/lolduo/duo/service/ChampionDetailComponent2.java
@@ -65,7 +65,7 @@ public class ChampionDetailComponent2 {
         return spellList;
     }
     public List<Perk> pickPerkList(@NotNull ICombiEntity combiEntity){
-        List<Perk> perkList =new ArrayList<>();
+        List<Perk> perkList = new ArrayList<>();
         findTopK(combiEntity.getPerkList(),2).forEach(perk->{
             perkList.add((Perk)perk);
         });
@@ -139,14 +139,43 @@ public class ChampionDetailComponent2 {
         return responseItemList;
     }
     public List<Item> pickItemList(@NotNull ICombiEntity combiEntity){
-        List<Item> itemList =new ArrayList<>();
-        removeItemsAmountUnderThree(combiEntity);
-        findTopK(combiEntity.getItemList(),3).forEach(item ->
-                itemList.add((Item)item));
-        return itemList;
+        removeItemsAmountUnderNumber(combiEntity, 3);
+        List<Item> summarizedItemList = new ArrayList<>();
+        findTopK(getSummarizedItemList(combiEntity),3).forEach(item ->
+                summarizedItemList.add((Item)item));
+        return summarizedItemList;
     }
-    private void removeItemsAmountUnderThree(ICombiEntity infoEntity) {
-        infoEntity.getItemList().removeIf(item -> {
+    private List<Item> getSummarizedItemList(ICombiEntity combiEntity) {
+        Map<Map<Long, List<Long>>, List<Long>> itemCombiAndWinAllCountsMap = new HashMap<>();
+        List<Item> summarizedItemList = new ArrayList<>();
+
+        combiEntity.getItemList().forEach(item -> {
+            Map<Long, List<Long>> champThreeItemMap = new HashMap<>();
+            item.getItemMap().forEach((championId, wholeItemList) ->
+                    champThreeItemMap.put(championId, wholeItemList.subList(0, 3))
+            );
+
+            if(itemCombiAndWinAllCountsMap.containsKey(champThreeItemMap)) {
+                List<Long> winAndAllCounts = itemCombiAndWinAllCountsMap.get(champThreeItemMap);
+                winAndAllCounts.set(0, winAndAllCounts.get(0) + item.getWin());
+                winAndAllCounts.set(1, winAndAllCounts.get(1) + item.getAllCount());
+            }
+            else {
+                List<Long> winAndAllCounts = new ArrayList<>(2);
+                winAndAllCounts.add(item.getWin());
+                winAndAllCounts.add(item.getAllCount());
+                itemCombiAndWinAllCountsMap.put(champThreeItemMap, winAndAllCounts);
+            }
+        });
+
+        itemCombiAndWinAllCountsMap.forEach((threeItemMap, winAndAllCounts) ->
+                summarizedItemList.add(new Item(threeItemMap, winAndAllCounts.get(0), winAndAllCounts.get(1)))
+        );
+
+        return summarizedItemList;
+    }
+    private void removeItemsAmountUnderNumber(ICombiEntity CombiEntity, int number) {
+        CombiEntity.getItemList().removeIf(item -> {
             for (List<Long> itemIdList : item.getItemMap().values()) {
                 int count = 0;
                 for (Long itemId : itemIdList) {
@@ -156,7 +185,7 @@ public class ChampionDetailComponent2 {
                         count++;
                 }
 
-                if (count < 3)
+                if (count < number)
                     return true;
             }
             return false;
@@ -213,12 +242,36 @@ public class ChampionDetailComponent2 {
                     statModRowList.get(1).initActivePerkIndexWithId(5008L);
                     statModRowList.get(2).initActivePerkIndex(activeStatModList);
                 }
+                else if (Collections.frequency(activeStatModList, 5002L) == 2) {
+                    statModRowList.get(1).initActivePerkIndexWithId(5002L);
+                    statModRowList.get(2).initActivePerkIndexWithId(5002L);
+                }
+                else if (Collections.frequency(activeStatModList, 5003L) == 2) {
+                    statModRowList.get(1).initActivePerkIndexWithId(5003L);
+                    statModRowList.get(2).initActivePerkIndexWithId(5003L);
+                }
+                else {
+                    statModRowList.get(1).initActivePerkIndexWithId(5002L);
+                    statModRowList.get(2).initActivePerkIndexWithId(5003L);
+                }
             }
             else if (activeStatModList.contains(5007L)) { // 5007 - ? - ?
                 statModRowList.get(0).initActivePerkIndexWithId(5007L);
                 if (activeStatModList.contains(5008L)) { // 5007 - 5008 - ?
                     statModRowList.get(1).initActivePerkIndexWithId(5008L);
                     statModRowList.get(2).initActivePerkIndex(activeStatModList);
+                }
+                else if (Collections.frequency(activeStatModList, 5002L) == 2) {
+                    statModRowList.get(1).initActivePerkIndexWithId(5002L);
+                    statModRowList.get(2).initActivePerkIndexWithId(5002L);
+                }
+                else if (Collections.frequency(activeStatModList, 5003L) == 2) {
+                    statModRowList.get(1).initActivePerkIndexWithId(5003L);
+                    statModRowList.get(2).initActivePerkIndexWithId(5003L);
+                }
+                else {
+                    statModRowList.get(1).initActivePerkIndexWithId(5002L);
+                    statModRowList.get(2).initActivePerkIndexWithId(5003L);
                 }
             }
             else { // 5008 - ? - ?

--- a/src/main/java/com/lolduo/duo/service/temp/PerkFormationMap.java
+++ b/src/main/java/com/lolduo/duo/service/temp/PerkFormationMap.java
@@ -323,25 +323,21 @@ public class PerkFormationMap {
             for (int index = 0; index < perkUrlListDisableApplied.size(); index++) {
                 if (index != activePerkIndex)
                     perkUrlListDisableApplied.set(index, perkUrlList.get(index) + "_disabled.png");
-                /*
-                else
-                    perkUrlListDisableApplied.set(index, perkUrlList.get(index).copy);
-                */
             }
-            log.info("getPerkUrlListDisableApplied - perkId : {}, activePerkIndex : {}", perkIdList.toString(), activePerkIndex);
+            log.info("getPerkUrlListDisableApplied - perkId : {}, activePerkIndex : {}", perkIdList, activePerkIndex);
             return perkUrlListDisableApplied;
         }
 
         public void initActivePerkIndex(List<Long> activePerkList) {
             int index = 0;
             activePerkIndex = -1;
-            log.info("initActivePerkIndexWithId - activePerkList : {}, perkCheck's perkIdList : {}", activePerkList.toString(), perkIdList);
+            log.info("initActivePerkIndex - activePerkList : {}, perkCheck's perkIdList : {}", activePerkList.toString(), perkIdList);
             for (Long perkId : perkIdList) {
                 if (activePerkList.contains(perkId))
                     activePerkIndex = index;
                 index++;
             }
-            log.info("initActivePerkIndex - perkId : {}, activePerkIndex : {}", perkIdList.toString(), activePerkIndex);
+            log.info("initActivePerkIndex - activePerkIndex : {}", activePerkIndex);
         }
 
         public void initActivePerkIndexWithId(Long activePerkId) {
@@ -353,7 +349,7 @@ public class PerkFormationMap {
                     activePerkIndex = index;
                 index++;
             }
-            log.info("initActivePerkIndexWithId - perkId : {}, activePerkIndex : {}", perkIdList.toString(), activePerkIndex);
+            log.info("initActivePerkIndexWithId - activePerkIndex : {}", activePerkIndex);
         }
     }
 }


### PR DESCRIPTION
조합 요약 페이지에서 앞의 세 아이템이 같으면 하나로 취급하는 함수 적용.
사용하지 않는 스탯 룬 이미지 disable이 정상적으로 이뤄지지 않는 이슈 수정.