### PR TITLE
[FIX] 조합 요약 페이지 중복 스펠 합칠 때 AllCount와 WinCount 안 합쳐지는 문제 수정

### DIFF
--- a/src/main/java/com/lolduo/duo/service/ChampionDetailComponent2.java
+++ b/src/main/java/com/lolduo/duo/service/ChampionDetailComponent2.java
@@ -40,13 +40,29 @@ public class ChampionDetailComponent2 {
     public List<ResponseSpell2> makeSpellList(List<Spell> spellList,Long championId){
         List<ResponseSpell2> responseSpellList = new ArrayList<>();
         List<Set<Long>> addedSpellIdSetList = new ArrayList<>();
+        Map<Set<Long>, List<Long>> spellIdSetAndWinAllCountsMap = new HashMap<>();
+
+        for(Spell spell : spellList){
+            if (!spellIdSetAndWinAllCountsMap.containsKey(spell.getSpellMap().get(championId))) {
+                List<Long> winAllCounts = new ArrayList<>();
+                winAllCounts.add(spell.getWin());
+                winAllCounts.add(spell.getAllCount());
+                spellIdSetAndWinAllCountsMap.put(spell.getSpellMap().get(championId), winAllCounts);
+            }
+            else {
+                List<Long> winAllCounts = spellIdSetAndWinAllCountsMap.get(spell.getSpellMap().get(championId));
+                winAllCounts.set(0, winAllCounts.get(0) + spell.getWin());
+                winAllCounts.set(1, winAllCounts.get(1) + spell.getAllCount());
+            }
+        }
 
         for(Spell spell : spellList){
             if (!addedSpellIdSetList.contains(spell.getSpellMap().get(championId))) {
                 addedSpellIdSetList.add(spell.getSpellMap().get(championId));
 
-                String winRate = String.format("%.2f%%", 100 * ((double) spell.getWin() / spell.getAllCount()));
-                String AllCount = String.valueOf(spell.getAllCount()).replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + " 게임";
+                List<Long> winAllCounts = spellIdSetAndWinAllCountsMap.get(spell.getSpellMap().get(championId));
+                String winRate = String.format("%.2f%%", 100 * ((double) winAllCounts.get(0) / winAllCounts.get(1)));
+                String AllCount = String.valueOf(winAllCounts.get(1)).replaceAll("\\B(?=(\\d{3})+(?!\\d))", ",") + " 게임";
 
                 List<String> spellUrlList = new ArrayList<>();
                 for (Long spellId : spell.getSpellMap().get(championId)) {


### PR DESCRIPTION
듀오 이상에서 각 챔피언 별로 중복된 스펠을 합쳐 보여줄 때 행만 합쳐지고 AllCount와 WinRate는 그에 맞춰 합쳐지지 않는 문제가 있었음.
스펠 행들을 추가하기 전 각 챔피언 별로 각 (스펠id 리스트)와 (AllCount와 WinCount의 리스트)의 맵을 만들고, 중복되는 스펠 id 리스트에 대해 AllCount와 WinCount를 합계하여 저장한 뒤 스펠 행 추가 시 사용하도록 하였음.