### PR TITLE
[FEAT] combi 테이블들에 인덱스 추가 및 champion_id, position 컬럼 타입 수정

### DIFF
--- a/src/main/java/com/lolduo/duo/controller/ClientApi.java
+++ b/src/main/java/com/lolduo/duo/controller/ClientApi.java
@@ -33,7 +33,7 @@ public class ClientApi {
     }
 
     @GetMapping("/health")
-    @ApiOperation(value ="챔피언 리스트 반환", notes = "챔피언의 챔피언 id, 이름에 대한 정보를 제공한다.",response = Champion[].class)
+    @ApiOperation(value ="서버 정상 작동 여부 반환", notes = "서버의 HealthCheck 결과를 반환한다.",response = Champion[].class)
     public ResponseEntity<?> getHealth() {
         return healthCheckService.getHealthCheckResult();
     }

--- a/src/main/java/com/lolduo/duo/object/entity/clientInfo/DoubleCombiEntity.java
+++ b/src/main/java/com/lolduo/duo/object/entity/clientInfo/DoubleCombiEntity.java
@@ -15,7 +15,7 @@ import java.util.*;
 
 @Entity
 @NoArgsConstructor
-@Table(name = "double_combi")
+@Table(name = "double_combi", indexes = @Index(name = "idx_pos_champ_win_all", columnList = "position, champion_id, win_count, all_count"))
 @Getter
 @TypeDef(name = "json", typeClass = JsonType.class,defaultForType = JsonNode.class)
 public class DoubleCombiEntity implements ICombiEntity {
@@ -25,11 +25,11 @@ public class DoubleCombiEntity implements ICombiEntity {
     private Long id;
 
     @Type(type = "json")
-    @Column(name = "champion_id",columnDefinition = "json")
+    @Column(name = "champion_id",columnDefinition = "varchar(50)")
     private TreeSet<Long> championId = new TreeSet<>();
 
     @Type(type = "json")
-    @Column(name = "position", columnDefinition = "json")
+    @Column(name = "position", columnDefinition = "varchar(100)")
     private Map<Long, String> position = new HashMap<>();
 
     @Column(name = "perk_myth_item")

--- a/src/main/java/com/lolduo/duo/object/entity/clientInfo/PentaCombiEntity.java
+++ b/src/main/java/com/lolduo/duo/object/entity/clientInfo/PentaCombiEntity.java
@@ -18,7 +18,7 @@ import java.util.TreeSet;
 
 @Entity
 @NoArgsConstructor
-@Table(name = "penta_combi")
+@Table(name = "penta_combi", indexes = @Index(name = "idx_pos_champ_win_all", columnList = "position, champion_id, win_count, all_count"))
 @Getter
 @TypeDef(name = "json", typeClass = JsonType.class,defaultForType = JsonNode.class)
 public class PentaCombiEntity implements Serializable, ICombiEntity {
@@ -27,10 +27,10 @@ public class PentaCombiEntity implements Serializable, ICombiEntity {
     @Column(name = "id")
     private Long id;
     @Type(type = "json")
-    @Column(name = "champion_id",columnDefinition = "json")
+    @Column(name = "champion_id",columnDefinition = "varchar(50)")
     private TreeSet<Long> championId;
     @Type(type = "json")
-    @Column(name = "position", columnDefinition = "json")
+    @Column(name = "position", columnDefinition = "varchar(100)")
     private Map<Long, String> position;
     @Column(name = "perk_myth_item")
     private String perkMythItem;

--- a/src/main/java/com/lolduo/duo/object/entity/clientInfo/SoloCombiEntity.java
+++ b/src/main/java/com/lolduo/duo/object/entity/clientInfo/SoloCombiEntity.java
@@ -15,7 +15,7 @@ import java.util.*;
 
 @Entity
 @NoArgsConstructor
-@Table(name = "solo_combi")
+@Table(name = "solo_combi", indexes = @Index(name = "idx_pos_champ_win_all", columnList = "position, champion_id, win_count, all_count"))
 @Getter
 @TypeDef(name = "json", typeClass = JsonType.class,defaultForType = JsonNode.class)
 public class SoloCombiEntity implements ICombiEntity {
@@ -25,11 +25,11 @@ public class SoloCombiEntity implements ICombiEntity {
     private Long id;
 
     @Type(type = "json")
-    @Column(name = "champion_id",columnDefinition = "json")
+    @Column(name = "champion_id",columnDefinition = "varchar(50)")
     private TreeSet<Long> championId = new TreeSet<>();
 
     @Type(type = "json")
-    @Column(name = "position", columnDefinition = "json")
+    @Column(name = "position", columnDefinition = "varchar(100)")
     private Map<Long, String> position = new HashMap<>();
 
     @Column(name = "perk_myth_item")

--- a/src/main/java/com/lolduo/duo/object/entity/clientInfo/TripleCombiEntity.java
+++ b/src/main/java/com/lolduo/duo/object/entity/clientInfo/TripleCombiEntity.java
@@ -18,7 +18,7 @@ import java.util.TreeSet;
 
 @Entity
 @NoArgsConstructor
-@Table(name = "triple_combi")
+@Table(name = "triple_combi", indexes = @Index(name = "idx_pos_champ_win_all", columnList = "position, champion_id, win_count, all_count"))
 @Getter
 @TypeDef(name = "json", typeClass = JsonType.class,defaultForType = JsonNode.class)
 public class TripleCombiEntity implements Serializable, ICombiEntity {
@@ -28,11 +28,11 @@ public class TripleCombiEntity implements Serializable, ICombiEntity {
     private Long id;
 
     @Type(type = "json")
-    @Column(name = "champion_id",columnDefinition = "json")
+    @Column(name = "champion_id",columnDefinition = "varchar(50)")
     private TreeSet<Long> championId;
 
     @Type(type = "json")
-    @Column(name = "position", columnDefinition = "json")
+    @Column(name = "position", columnDefinition = "varchar(100)")
     private Map<Long, String> position;
 
     @Column(name = "perk_myth_item")


### PR DESCRIPTION
1. solo_combi ~ penta_combi 테이블 각각에 position, champion_id, win_count, all_count를 색인하는 복합 인덱스 추가.
2. solo_combi ~ penta_combi 테이블에서 position과 champion_id가 json (longtext) 타입 대신 varchar 타입을 사용하도록 변경
3. helathCheck API Swagger 설명 변경